### PR TITLE
Update docker-compose to use GHCR image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   web:
-    image: hartlco/masto_rss:v0.0.2
+    image: ghcr.io/hartlco/masto_rss:main
     ports:
       - "6060:6060"
     restart: unless-stopped


### PR DESCRIPTION
### Motivation

- Use the GHCR-hosted image instead of the pinned Docker Hub tag to reference the artifact produced by GitHub Actions.
- Update the example compose to point at the `main` tag so deployments use the latest build.

### Description

- Change `image` in `docker-compose.yml` from `hartlco/masto_rss:v0.0.2` to `ghcr.io/hartlco/masto_rss:main`.
- No other configuration changes were made.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69620d77e5948332bd2145b61c956796)