### PR TITLE
Update Rust base image to support Cargo.lock v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # https://github.com/rogertorres/dev.to/blob/main/docker/holodeck/Dockerfile5 
 
 # Rust as the base image
-FROM rust:1.74 as build
+FROM rust:1.78 AS build
 
 # Create a new empty shell project
 RUN USER=root cargo new --bin masto_rss
@@ -23,7 +23,7 @@ RUN rm ./target/release/deps/masto_rss*
 RUN cargo build --release
 
 # The final base image
-FROM rust:1.74-slim-buster
+FROM rust:1.78-slim-buster
 
 # Copy from the previous build
 COPY --from=build /masto_rss/target/release/masto_rss /usr/src/masto_rss


### PR DESCRIPTION
### Motivation
- Docker image builds failed because `Cargo.lock` uses lockfile version `4` which older Cargo in the base image cannot parse.  
- The build step `cargo build --release` returned an exit code `101` during image creation due to the lockfile version mismatch.  
- The Dockerfile also raised a casing warning for the stage keyword which is trivial to align.  

### Description
- Bump the build and final base images from `rust:1.74`/`rust:1.74-slim-buster` to `rust:1.78`/`rust:1.78-slim-buster` in the `Dockerfile`.  
- Normalize the stage keyword casing to `AS build` to remove the Dockerfile warning.  
- All changes are limited to the `Dockerfile` and aim to ensure the bundled Cargo understands `Cargo.lock` v4.  

### Testing
- No automated tests were run in this environment; the Docker image build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69620e6466588332a2022c69916891f0)