### PR TITLE
Fix runtime OpenSSL dependency in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ RUN rm ./target/release/deps/masto_rss*
 RUN cargo build --release
 
 # The final base image
-FROM rust:1.78-slim-buster
+FROM rust:1.78-slim-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libssl3 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy from the previous build
 COPY --from=build /masto_rss/target/release/masto_rss /usr/src/masto_rss


### PR DESCRIPTION
### Motivation
- The container runtime was failing with `libssl.so.3` not found, indicating the OpenSSL runtime library is missing from the final image.
- The runtime stage used `slim-buster`, which doesn't provide `libssl3` needed by the built binary.
- Ensure the final image contains the system OpenSSL runtime and CA certificates so the binary can start.

### Description
- Updated the runtime base image from `rust:1.78-slim-buster` to `rust:1.78-slim-bookworm`.
- Installed `libssl3` and `ca-certificates` in the runtime image via `apt-get update && apt-get install -y --no-install-recommends libssl3 ca-certificates` and cleaned apt lists.
- Kept the multi-stage build and copy of the release binary from the `build` stage unchanged.

### Testing
- No automated tests were run (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696213d3b5348332a7e13bc95609fea5)