### PR TITLE
Mount .env in docker-compose runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     image: ghcr.io/hartlco/masto_rss:main
     env_file:
       - .env
+    working_dir: /usr/src
+    volumes:
+      - ./.env:/usr/src/.env:ro
     ports:
       - "6060:6060"
     restart: unless-stopped


### PR DESCRIPTION
### Motivation
- Ensure the application can read environment variables when started with `docker-compose` by making the `.env` file visible inside the container.
- Prevent runtime failures caused by missing variables such as `PORT` and `BLUESKY_*` credentials that are read via `dotenv` and `env::var`.
- Guarantee the container process resolves relative paths to `.env` by setting a predictable working directory of `/usr/src`.

### Description
- Updated `docker-compose.yml` to set `working_dir: /usr/src` for the `web` service.
- Added a read-only volume mapping for the environment file with `- ./.env:/usr/src/.env:ro`.
- Kept the existing `env_file: - .env` entry so docker-compose still parses the file at orchestration time.

### Testing
- No automated tests were run for this configuration-only change.
- This change only modifies runtime mounting and working directory in `docker-compose.yml` and does not alter application code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696281765a8483329a63277af2976fee)